### PR TITLE
Allow shift signup modal to be scrolled

### DIFF
--- a/client/components/shifts/SignupModal.jsx
+++ b/client/components/shifts/SignupModal.jsx
@@ -18,7 +18,7 @@ export const SignupModalComponent = ({
     isOpen={modalOpen}
     className="modal-dialog modal-lg"
     // We need to force Bootstrap to behave
-    style={{ overlay: { zIndex: 1030, backgroundColor: '#0008' } }}
+    style={{ overlay: { zIndex: 1030, backgroundColor: '#0008', overflow: 'scroll' } }}
     onRequestClose={() => showModal(false)}
   >
     <div className="modal-content">


### PR DESCRIPTION
Previously, if the list of shifts that are available extend beyond the current window's viewport, scrolling would only scroll the content behind the modal, not the modal's content itself.

To fix this, I'm adding overflow: scroll onto the overlay's styles. This is working for me on Chrome Desktop. I haven't tested it elsewhere, and I'm not convinced this is necessarily the right way to fix this.