### PR TITLE
Update for 2025

### DIFF
--- a/both/methods/dutiesMethods.js
+++ b/both/methods/dutiesMethods.js
@@ -156,8 +156,8 @@ export function initDutiesMethods(volunteersClass) {
           },
         ])
 
-        return [...results[0].projects, ...results[0].rotas]
-          .sort((a, b) => b.score - a.score)
+        return (results[0] && [...results[0].projects, ...results[0].rotas]
+          .sort((a, b) => b.score - a.score)) ?? []
       },
     }),
 

--- a/client/utils/methodUtils.js
+++ b/client/utils/methodUtils.js
@@ -36,7 +36,7 @@ export function meteorCall(VolClass, methodName, ...args) {
     nonCallbackArgs = args.slice(0, -1)
   }
   // TODO remove when blaze has been eradicated...
-  const Volunteers = VolClass || { eventName: 'nowhere2024' }
+  const Volunteers = VolClass || { eventName: 'nowhere2025' }
   Meteor.call(
     `${Volunteers.eventName}.Volunteers.${methodName}`,
     ...nonCallbackArgs,


### PR DESCRIPTION
Update the 'blaze hack' reference to 2024 to 25. It's very possible that this isn't needed any more...

Also fix a bug encountered when running with the new event name, before the 'new event' button has been pressed.