### PR TITLE
Ensure users are added to roles on signups.insert for non-public duties.

### DIFF
--- a/both/methods/signupMethods.js
+++ b/both/methods/signupMethods.js
@@ -186,7 +186,6 @@ export const initSignupMethods = (volunteersClass) => {
         throw new Meteor.Error(403, 'Admin only')
       }
       if ((signupIdentifiers.userId === this.userId) || isLead || isNoInfo) {
-        // Leads cannot be public so no special handling of roles needed in this method
         // FIXME should pass a flag to say we're voluntelling, so lead applications don't
         // automatically get approved for their teams
         const status = parentDuty.policy === 'public' || isLead || isNoInfo ? 'confirmed' : 'pending'
@@ -244,6 +243,9 @@ export const initSignupMethods = (volunteersClass) => {
               },
             },
           ])?.[0]?.rotas?.[0]
+        }
+        if (status === 'confirmed' && parentDuty.policy !== 'public') {
+          Roles.addUsersToRoles(signupIdentifiers.userId, parentDuty.parentId, eventName)
         }
         if (res && res.insertedId) {
           return {


### PR DESCRIPTION
Since https://github.com/goingnowhere/meteor-volunteers/commit/5a58d653f69fdf356e05c003c826931fb26152c1 allows direct insertion of new signups as "confirmed" no matter the duty policy (when previously signups would always be inserted as "pending" except for policy "public"), the signups.insert method now _does_ need to handle roles too.

(Without this change I could not locally as admin or manager turn test users fully into leads, since they never got assigned the respective roles, and therefore from their point of view never could access the (meta-)lead dashboards.)